### PR TITLE
Add two detection engineering resources to "concepts & frameworks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ All contributions are welcome, please carefully review the [contributing guideli
 - [MaGMa (Management, Growth and Metrics & Assessment) Use Case Defintion Model](https://www.betaalvereniging.nl/wp-content/uploads/FI-ISAC-use-case-framework-verkorte-versie.pdf) - A business-centric approach for defining threat detection use cases.
 - [Synthetic Adversarial Log Objects (SALO) | Splunk](https://github.com/splunk/salo) - Synthetic Adversarial Log Objects (SALO) is a framework for the generation of log events without the need for infrastructure or actions to initiate the event that causes a log event.
 - [The Zen of Security Rules | Justin Ibarra](https://br0k3nlab.com/resources/zen-of-security-rules/) - Outlines 19 aphorisms that serve as universal principles for the creation of high quality detection content.
-- [Blue-team-as-Code - the Spiral of Joy | Den Iuzvyk, Oleg Kolesnikov](https://sansorg.egnyte.com/dl/KTc16ldiqv) - Blue-Team-as-Code: Lessons From Real-world Red Team Detection Automation Using Logs
+- [Blue-team-as-Code - the Spiral of Joy | Den Iuzvyk, Oleg Kolesnikov](https://sansorg.egnyte.com/dl/KTc16ldiqv) - Blue-Team-as-Code: Lessons From Real-world Red Team Detection Automation Using Logs.
+- [Detection Development Lifecycle | Haider Dost et al.](https://medium.com/snowflake/detection-development-lifecycle-af166fffb3bc) - Snowflake’s implementation of the Detection Development Lifecycle.
+- [Threat Detection Maturity Framework | Haider Dost of Snowflake](https://medium.com/snowflake/threat-detection-maturity-framework-23bbb74db2bc) - A maturity matrix to measure the success of your threat detection program.
 
 ## Detection Content & Signatures
 


### PR DESCRIPTION
Why my contribution adds value to this list:
- I added two resources written by Haider Dost of Snowflake on Medium, which I both found helpful in writing and learning about detection engineering as a technical writer (I am not a practitioner):
   - a description/implementation of a detection development lifecycle for detection engineers
   - a threat detection maturity matrix which is broader in scope and does not specifically call out detection engineering

I also made a minor fix:
- Added a period at the end of line 25