### PR TITLE
Add m365-security-operations to Detection Content & Signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ All contributions are welcome, please carefully review the [contributing guideli
 - [KQL Advanced Hunting Queries & Analytics Rules](https://github.com/Bert-JanP/Hunting-Queries-Detection-Rules) - A list of endpoint detections and hunting queries for Microsoft Defender for Endpoint, Defender For Identity, and Defender For Cloud Apps.
 - [Sigma2KQL](https://github.com/Khadinxc/Sigma2KQL) - A repository of all SIGMA rules converted to KQL that runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository.
 - [TerraSigma](https://github.com/Khadinxc/TerraSigma) - A repository of all SIGMA rules converted to Microsoft Sentinel Terraform Scheduled analytic resources. The repository runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository. Proper entity mapping is completed for the rules to ensure the repo is plug-and-play.
+- [m365-security-operations | Ievgen Bondarenko](https://github.com/ibondarenko1/m365-security-operations) - Audit-and-remediate toolkit for Microsoft 365 plus Cloudflare in small organizations, with 5 MITRE-mapped Sentinel scheduled analytics rule ARM templates and 10 KQL hunting drills tagged with NIST CSF, NIST 800-53, ISO 27001, MITRE ATT&CK, and MCSB controls.
 - [Detections Digest | Sergey Polzunov](https://detections-digest.rulecheck.io) - A newsletter that features updates from many popular detection content sources listed here. 
 
 ## Logging, Monitoring & Data Sources


### PR DESCRIPTION
## What

Adding [m365-security-operations](https://github.com/ibondarenko1/m365-security-operations) to the **Detection Content & Signatures** section, placed alongside the existing Sentinel and KQL detection content entries (Bert-JanP/Hunting-Queries-Detection-Rules, Sigma2KQL, TerraSigma).

## Why it adds value to this list

The list already curates several detection content libraries for Microsoft Sentinel and Defender (Bert-JanP hunting queries, TerraSigma, Sigma2KQL). m365-security-operations is complementary rather than overlapping:

- **5 MITRE-mapped Sentinel scheduled analytics rule ARM templates** (T1098 Persistence, T1485 Impact, T1087 Discovery, T1098 PrivEsc, T1562 Defense Evasion) ready for `New-AzResourceGroupDeployment`.
- **10 KQL hunting drill templates** with documented FP-tuning patterns.
- **Framework-tagged**: every detection is tagged with NIST CSF 2.0, NIST 800-53, ISO 27001:2022, MITRE ATT&CK, and Microsoft Cloud Security Benchmark control references — useful for analysts working in regulated environments who need to defend choices to audit.

Unlike Sigma2KQL/TerraSigma which auto-translate the upstream Sigma corpus, m365-security-operations ships hand-authored detection content specific to the small-org M365 + Cloudflare attack surface (Conditional Access bypass, OAuth consent grant abuse, dormant identity exploitation, DKIM/SPF/DMARC drift).

## Quality bar

- MIT licensed
- v1.0 release with full test matrix (Pester suite on Windows + Linux + Mac CI, all green)
- Schema-first design (SCHEMA.md), 6 Architecture Decision Records documenting design rationale
- Mock mode (`examples/run-mock.ps1`) produces a sample run in 30 seconds without any Azure access, so reviewers can see the output without setup

## Format

Entry follows the contributing.md format:
\`\`\`
- [Short Title | Author](URL) - Brief description.
\`\`\`