### PR TITLE
Add Agent Threat Rules (ATR) to Detection Content & Signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All contributions are welcome, please carefully review the [contributing guideli
 - [Splunk Security Content](https://github.com/splunk/security_content) - Splunk's open-source and frequently updated detection content that can be tweaked for use in other tools.
 - [Elastic Detection Rules](https://github.com/elastic/detection-rules/tree/main/rules) - Elastic's detection rules written natively for the Elastic SIEM. Can easily be converted for use by other SIEMs using Uncoder.
 - [Elastic Endpoint Behavioral Rules](https://github.com/elastic/protections-artifacts/tree/main/behavior/rules) - Elastic's endpoint behavioral (prevention) rules written in EQL, natively for the Elastic endpoint agent.
+- [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - An open MIT detection-rule standard for AI-agent and MCP attacks (prompt injection, tool poisoning, context exfiltration), like Sigma or YARA for the agent layer, with OWASP LLM/Agentic and MITRE ATLAS mappings on each rule.
 - [Elastic Yara Signatures](https://github.com/elastic/protections-artifacts/tree/main/yara/rules) - Elastic's YARA signatures, which run on the Elastic endpoint agent.
 - [Elastic Endpoint Ransomware Artifact](https://github.com/elastic/protections-artifacts/blob/main/ransomware/artifact.lua) - Elastic's ranswomware artifact, which runs on the Elastic endpoint agent.
 - [Chronicle (GCP) Detection Rules](https://github.com/chronicle/detection-rules) - Chronicle's detection rules written natively for the the Chronicle Platform.


### PR DESCRIPTION
Adds [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) under Detection Content & Signatures.

ATR is an open, MIT-licensed detection-rule standard for AI-agent and MCP attacks (prompt injection, tool poisoning, context exfiltration) — the agent-layer analogue to the Sigma / Elastic / Splunk rulesets already listed in that section. Each rule carries OWASP LLM Top 10, OWASP Agentic, and MITRE ATLAS references.

Single line, in the existing entry format, placed with the other open detection-content repositories.