### PR TITLE
Add SOCTalk to Logging Monitoring and Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ All contributions are welcome, please carefully review the [contributing guideli
 - [Microsoft XDR Advanced Hunting Schema](https://learn.microsoft.com/en-us/defender-xdr/advanced-hunting-schema-tables) To help with multi-table queries, you can use the advanced hunting schema, which includes tables and columns with event information and details about devices, alerts, identities, and other entity types.
 - [InnerWarden](https://github.com/InnerWarden/innerwarden) - Autonomous security agent for Linux with real-time threat detection and response via 38 eBPF hooks, 48 detectors, and 23 correlation rules.
 - [Rustinel | Karib0u](https://github.com/Karib0u/rustinel) - Open-source endpoint detection engine for Windows and Linux that collects ETW/eBPF telemetry and evaluates Sigma, YARA, and IOC detections.
+- [SOCTalk](https://github.com/soctalk/soctalk) - Open source, LLM driven SOC automation platform for MSPs and MSSPs built on Wazuh. Triages, investigates, and escalates alerts through a two tier AI pipeline with human in the loop review, multi tenant isolation, and a no code triage policy editor backed by deterministic execution. Apache 2.0.
 
 ## General Resources
  


### PR DESCRIPTION
SOCTalk is an open source (Apache 2.0) SOC automation platform for MSPs and MSSPs that sits directly on top of Wazuh. It belongs in the Logging, Monitoring and Data Sources section as a full platform that ingests Wazuh alerts, runs them through a two tier LLM triage pipeline, and produces investigated cases with verdicts and evidence for analyst review. The no code triage policy editor lets detection engineers define deterministic guardrails over the AI layer, ensuring detection logic stays explicit and auditable rather than opaque. Every alert decision is recorded in an append only event sourced audit log. The platform supports multi tenant deployments with one isolated Kubernetes namespace per customer, making it practical for detection engineering teams inside MSP and MSSP environments. Released v0.2 on July 21 2026, actively maintained by Atricore Inc.